### PR TITLE
Fix: Ensure wake lock can be re-acquired after app visibility change

### DIFF
--- a/index.html
+++ b/index.html
@@ -474,6 +474,17 @@
             const wakeLockStatusIcon = document.querySelector('.wake-lock-status');
             let wakeLock = null;
 
+            // Function to add event listeners for acquiring wake lock
+            function addWakeLockListeners() {
+                // Remove any existing listeners to prevent duplicates if called multiple times
+                document.body.removeEventListener('click', requestWakeLock);
+                document.body.removeEventListener('touchstart', requestWakeLock);
+
+                // Add new listeners with { once: true }
+                document.body.addEventListener('click', requestWakeLock, { once: true });
+                document.body.addEventListener('touchstart', requestWakeLock, { once: true });
+            }
+
             async function requestWakeLock() {
                 try {
                     wakeLock = await navigator.wakeLock.request('screen');
@@ -485,43 +496,43 @@
                         console.log('Screen Wake Lock was released.');
                         wakeLockStatusIcon.style.display = 'block'; // Show icon
                         wakeLock = null; // Reset wakeLock variable
+                        // If lock is released, allow user to acquire it again
+                        if (document.visibilityState === 'visible') {
+                           addWakeLockListeners();
+                        }
                     });
                 } catch (err) {
                     console.error(`${err.name}, ${err.message}`);
                     // Keep icon visible if request fails or is denied
                     wakeLockStatusIcon.style.display = 'block';
+                    // If request fails, ensure listeners are still there for another attempt
+                    if (document.visibilityState === 'visible') {
+                        addWakeLockListeners();
+                    }
                 }
             }
 
             if ('wakeLock' in navigator) {
                 console.log('Screen Wake Lock API supported.');
                 wakeLockStatusIcon.style.display = 'block'; // Show icon as wake lock is not yet active
+                addWakeLockListeners(); // Set up initial listeners
 
-                // Request wake lock on user interaction
-                document.body.addEventListener('click', requestWakeLock, { once: true });
-                document.body.addEventListener('touchstart', requestWakeLock, { once: true });
-
-                // Re-acquire wake lock if page becomes visible again
-                // And it was active before becoming hidden
                 document.addEventListener('visibilitychange', async () => {
-                    if (wakeLock !== null && document.visibilityState === 'visible') {
-                        // If wakeLock was active before page was hidden, re-request it
-                        // No need to show the icon here, as requestWakeLock will handle it
-                        await requestWakeLock();
-                    } else if (wakeLock === null && document.visibilityState === 'visible') {
-                        // If wakeLock was not active (e.g. released due to timeout or manually)
-                        // and page becomes visible, show icon and allow re-request
-                        wakeLockStatusIcon.style.display = 'block';
-                        // Re-add event listeners if they were {once: true} and have been consumed
-                        // However, in this setup, if wakeLock is null, it implies it was released,
-                        // and the icon is shown, allowing a new click to acquire.
-                        // If it was released and the user hasn't clicked again, the icon remains.
-                        // If they click, requestWakeLock is called.
-                        // Let's ensure listeners are available if it was released and page is visible.
-                        // A simple way is to ensure they are not {once:true} if we want to re-enable by visibility.
-                        // For now, the user must click again if it's released.
-                        // The problem asks for a click/touch to enable, so this is consistent.
-                        // If the wake lock was released (e.g. by system), the icon shows, user clicks again.
+                    if (document.visibilityState === 'visible') {
+                        if (wakeLock === null) {
+                            // Wake lock is not active, show icon and ensure listeners are set
+                            console.log('Page visible, wake lock is null. Showing icon and adding listeners.');
+                            wakeLockStatusIcon.style.display = 'block';
+                            addWakeLockListeners();
+                        } else {
+                            // Wake lock is already active (or browser re-acquired it).
+                            // This case might happen if the browser automatically re-acquires the lock.
+                            // We should ensure the icon is hidden.
+                            console.log('Page visible, wake lock is active. Hiding icon.');
+                            wakeLockStatusIcon.style.display = 'none';
+                            // No need to add listeners as lock is active.
+                            // The 'release' event on the wakeLock itself will handle re-adding them if it's later released.
+                        }
                     }
                 });
 


### PR DESCRIPTION
Previously, if the app was backgrounded and then foregrounded, the 'zzz' icon would reappear, but the click/touch listeners to re-acquire the wake lock were not re-attached.

This commit modifies the wake lock logic:
- Introduces an `addWakeLockListeners` function that removes any existing listeners before adding new ones with `{ once: true }`.
- This function is now called:
  - Initially when the page loads.
  - When a wake lock is released while the page is visible.
  - When a wake lock request fails while the page is visible.
  - When the page becomes visible and the wake lock is not currently active.

This ensures that the user can always click/tap the screen to attempt to acquire the wake lock whenever the 'zzz' icon is visible.